### PR TITLE
Fixed broken "View settings" Link

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -35,7 +35,11 @@
                </p>
 	        </form>
 		</div>
-		<p><a id = 'goto1' onClick="window.open(chrome.extension.getURL('options.html'))" href = "chrome.extension.getURL('options.html')"> View Settings</a></p>
+		<!--WORKING OPTIONS LINK CODE-->
+		<p><a href = "options.html">View Settings</a></p>
+		<!--OLD OPTIONS LINK CODE
+		<p><a id = 'goto1' onClick="window.open(chrome.runtime.getURL('options.html'))" href = "chrome.runtime.getURL('options.html')"> View Settings</a></p>
+		-->
 		<script type="text/javascript" src="entries.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Stopped using "onClick" as this is no longer allowed in manifest 2.0. Instead used a simple link.